### PR TITLE
Fix broken link to YouTube

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ This project has a [dev container configuration](.devcontainer/), which makes it
 
 This project is designed to work well with the [Azure Developer CLI](https://learn.microsoft.com/azure/developer/azure-developer-cli/overview), which makes it easier to develop apps locally, deploy them to Azure, and monitor them. 
 
-🎥 Watch a deployment of the code in [this screencast](https://www
-.youtube.com/watch?v=JDlZ4TgPKYc).
+🎥 Watch a deployment of the code in [this screencast](https://www.youtube.com/watch?v=JDlZ4TgPKYc).
 
 Steps for deployment:
 


### PR DESCRIPTION
The link to the screencast is broken because the link is split in two lines.